### PR TITLE
Fix npm install error

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -79,7 +79,7 @@
     </platform>
     <engine name="android" spec="^6.2.3" />
     <engine name="browser" spec="^4.1.0" />
-    <plugin name="com.msopentech.authdialog" spec="~0.1.6" />
+    <plugin name="cordova-plugin-auth-dialog" spec="^0.1.6" />
     <plugin name="cordova-plugin-compat" spec="^1.1.0" />
     <plugin name="cordova-plugin-console" spec="^1.0.5" />
     <plugin name="cordova-plugin-device" spec="^1.1.4" />

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
         "ionicons": "3.0.0",
         "rxjs": "5.1.1",
         "sw-toolbox": "3.6.0",
-        "zone.js": "0.8.11",
-        "com.msopentech.authdialog": "~0.1.6"
+        "zone.js": "0.8.11"
     },
     "devDependencies": {
         "@ionic/app-scripts": "1.3.7",


### PR DESCRIPTION
`npm install` results in failure because *com.msopentech.authdialog* is not in the npm registry. However, removing it from the dependeny list seems no harm to the app.